### PR TITLE
Make Reference::isValid static

### DIFF
--- a/engine/src/main/java/org/dragonskulle/audio/AudioManager.java
+++ b/engine/src/main/java/org/dragonskulle/audio/AudioManager.java
@@ -239,7 +239,7 @@ public class AudioManager {
         }
 
         // First remove any references to AudioSources that are no longer valid
-        mAudioSources.removeIf(ref -> !ref.isValid());
+        mAudioSources.removeIf(Reference::isInvalid);
 
         // All references will be valid because they any invalid ones are removed at the start
         for (int i = 0; i < mAudioSources.size(); i++) {
@@ -247,7 +247,7 @@ public class AudioManager {
 
             // Get the distance of the source from the listener
             float distance = 100000f;
-            if (mAudioListener != null && mAudioListener.isValid()) {
+            if (Reference.isValid(mAudioListener)) {
                 distance = mAudioListener.get().getPosition().distance(audioSource.getPosition());
             }
 

--- a/engine/src/main/java/org/dragonskulle/core/Reference.java
+++ b/engine/src/main/java/org/dragonskulle/core/Reference.java
@@ -45,10 +45,23 @@ public class Reference<T> implements Serializable {
     /**
      * Check whether the reference has been cleared
      *
-     * @return true if the reference is still valid, false otherwise
+     * @param ref reference to check
+     * @return {@code true} if the reference is non-null and still valid, {@code false} otherwise
      */
-    public boolean isValid() {
-        return mObject != null;
+    public static boolean isValid(Reference<?> ref) {
+        return ref != null && ref.mObject != null;
+    }
+
+    /**
+     * Check whether the reference has been cleared
+     *
+     * <p>This method is opposite of {@link isValid}
+     *
+     * @param ref reference to check
+     * @return {@code false} if the reference is non-null and still valid, {@code true} otherwise
+     */
+    public static boolean isInvalid(Reference<?> ref) {
+        return !isValid(ref);
     }
 
     /**

--- a/engine/src/main/java/org/dragonskulle/core/Scene.java
+++ b/engine/src/main/java/org/dragonskulle/core/Scene.java
@@ -110,7 +110,7 @@ public class Scene {
         Class<?> type = comp.getClass();
         Reference<Component> current = mSingletons.get(type);
 
-        if (current != null && current.isValid()) return false;
+        if (Reference.isValid(current)) return false;
 
         current = comp.getReference();
         mSingletons.put(type, current);
@@ -126,7 +126,7 @@ public class Scene {
     @SuppressWarnings("unchecked")
     public <T extends Component> T getSingleton(Class<T> type) {
         Reference<Component> current = mSingletons.get(type);
-        if (current == null || !current.isValid()) return null;
+        if (!Reference.isValid(current)) return null;
         return (T) current.get();
     }
 

--- a/engine/src/main/java/org/dragonskulle/devtools/RenderDebug.java
+++ b/engine/src/main/java/org/dragonskulle/devtools/RenderDebug.java
@@ -55,7 +55,7 @@ public class RenderDebug extends Component implements IOnAwake, IFrameUpdate {
     public void frameUpdate(float deltaTime) {
         boolean debugPressed = DEBUG_ACTION.isActivated();
 
-        if (mText != null && mText.isValid()) {
+        if (Reference.isValid(mText)) {
             if (debugPressed && !mLastPressed) mText.get().setEnabled(!mText.get().isEnabled());
 
             mLastPressed = debugPressed;

--- a/engine/src/main/java/org/dragonskulle/network/components/ClientNetworkManager.java
+++ b/engine/src/main/java/org/dragonskulle/network/components/ClientNetworkManager.java
@@ -307,7 +307,7 @@ public class ClientNetworkManager {
 
         mNetworkObjectReferences
                 .entrySet()
-                .removeIf(entry -> !entry.getValue().mNetworkObject.isValid());
+                .removeIf(entry -> !Reference.isValid(entry.getValue().mNetworkObject));
     }
 
     // TODO: implement lobby

--- a/engine/src/main/java/org/dragonskulle/network/components/NetworkObject.java
+++ b/engine/src/main/java/org/dragonskulle/network/components/NetworkObject.java
@@ -99,7 +99,7 @@ public class NetworkObject extends Component {
     private void checkedOwnerIdSet(int newOwnerId) {
         if (newOwnerId != mOwnerId) {
             for (Reference<NetworkableComponent> netComp : mNetworkableComponents) {
-                if (netComp.isValid()) netComp.get().onOwnerIdChange(newOwnerId);
+                if (Reference.isValid(netComp)) netComp.get().onOwnerIdChange(newOwnerId);
             }
 
             mOwnerId = newOwnerId;

--- a/engine/src/main/java/org/dragonskulle/ui/UIButton.java
+++ b/engine/src/main/java/org/dragonskulle/ui/UIButton.java
@@ -322,7 +322,7 @@ public class UIButton extends Component implements IOnAwake, IFrameUpdate {
     @Override
     public void onAwake() {
         mRenderable = getGameObject().getComponent(UIRenderable.class);
-        if (mRenderable == null || !mRenderable.isValid()) {
+        if (!Reference.isValid(mRenderable)) {
             getGameObject()
                     .addComponent(new UIRenderable(new SampledTexture("ui/wide_button.png")));
             mRenderable = getGameObject().getComponent(UIRenderable.class);

--- a/engine/src/test/java/org/dragonskulle/core/ReferenceTest.java
+++ b/engine/src/test/java/org/dragonskulle/core/ReferenceTest.java
@@ -47,10 +47,11 @@ public class ReferenceTest {
         Object obj1 = new Object();
         Reference<Object> ref = new Reference<>(obj1);
 
-        Assert.assertTrue("Reference was invalid when it was actually valid", ref.isValid());
+        Assert.assertTrue(
+                "Reference was invalid when it was actually valid", Reference.isValid(ref));
 
         ref.clear();
 
-        Assert.assertFalse("Reference was still valid after being cleared", ref.isValid());
+        Assert.assertFalse("Reference was still valid after being cleared", Reference.isValid(ref));
     }
 }

--- a/game/src/main/java/org/dragonskulle/game/App.java
+++ b/game/src/main/java/org/dragonskulle/game/App.java
@@ -495,15 +495,16 @@ public class App implements NativeResource {
                                                                             onConnectedClient(
                                                                                     gameScene,
                                                                                     manager, netID);
-                                                                        } else if (connectingTextRef
-                                                                                .isValid()) {
+                                                                        } else if (Reference
+                                                                                .isValid(
+                                                                                        connectingTextRef)) {
                                                                             connectingTextRef
                                                                                     .get()
                                                                                     .setEnabled(
                                                                                             false);
                                                                         }
                                                                     });
-                                                    if (connectingTextRef.isValid())
+                                                    if (Reference.isValid(connectingTextRef))
                                                         connectingTextRef.get().setEnabled(true);
                                                 });
                                 button.addComponent(newButton);

--- a/game/src/main/java/org/dragonskulle/game/building/Building.java
+++ b/game/src/main/java/org/dragonskulle/game/building/Building.java
@@ -110,7 +110,7 @@ public class Building extends NetworkableComponent implements IOnAwake, IOnStart
             log.severe("Scene Map is null");
         } else {
             Reference<HexagonMap> mapCheck = checkingMapExists.getReference(HexagonMap.class);
-            if (mapCheck != null && mapCheck.isValid()) {
+            if (Reference.isValid(mapCheck)) {
                 mMap = mapCheck;
             } else {
                 log.severe("mapCheck is null.");

--- a/game/src/main/java/org/dragonskulle/game/building/stat/SyncStat.java
+++ b/game/src/main/java/org/dragonskulle/game/building/stat/SyncStat.java
@@ -116,7 +116,7 @@ public class SyncStat extends SyncInt {
         super.deserialize(in);
 
         // The stats have changed, so call the building's afterStatChange.
-        if (mBuilding == null || mBuilding.isValid() == false) return;
+        if (!Reference.isValid(mBuilding)) return;
         mBuilding.get().afterStatChange();
     }
 

--- a/game/src/main/java/org/dragonskulle/game/camera/TargetMovement.java
+++ b/game/src/main/java/org/dragonskulle/game/camera/TargetMovement.java
@@ -53,7 +53,7 @@ public class TargetMovement extends Component implements IFrameUpdate, IOnAwake 
 
     @Override
     public void frameUpdate(float deltaTime) {
-        if (mTransform != null && mTarget != null && mTarget.isValid()) {
+        if (mTransform != null && Reference.isValid(mTarget)) {
 
             mTransform.getPosition(mTmpVec1);
             mTarget.get().getPosition(mTmpVec2);

--- a/game/src/main/java/org/dragonskulle/game/map/FogOfWar.java
+++ b/game/src/main/java/org/dragonskulle/game/map/FogOfWar.java
@@ -75,7 +75,7 @@ public class FogOfWar extends Component implements IOnStart, ILateFrameUpdate {
     @Override
     protected void onDestroy() {
         for (Reference<GameObject> go : mFogTiles.values()) {
-            if (go.isValid()) {
+            if (Reference.isValid(go)) {
                 go.get().destroy();
             }
         }
@@ -95,7 +95,7 @@ public class FogOfWar extends Component implements IOnStart, ILateFrameUpdate {
     private void setFog(HexagonTile tile, boolean enable) {
         if (!enable) {
             Reference<GameObject> go = mFogTiles.remove(tile);
-            if (go != null && go.isValid()) go.get().destroy();
+            if (Reference.isValid(go)) go.get().destroy();
             return;
         }
 

--- a/game/src/main/java/org/dragonskulle/game/map/HexagonTile.java
+++ b/game/src/main/java/org/dragonskulle/game/map/HexagonTile.java
@@ -169,7 +169,7 @@ public class HexagonTile {
      * @return Whether the tile is claimed by a building.
      */
     public boolean isClaimed() {
-        return (mClaimedBy != null && mClaimedBy.isValid());
+        return Reference.isValid(mClaimedBy);
     }
 
     /**
@@ -223,7 +223,7 @@ public class HexagonTile {
      * @return The Building on the HexagonTile, otherwise {@code null}.
      */
     public Building getBuilding() {
-        if (mBuilding == null || mBuilding.isValid() == false) return null;
+        if (!Reference.isValid(mBuilding)) return null;
 
         return mBuilding.get();
     }

--- a/game/src/main/java/org/dragonskulle/game/map/MapEffects.java
+++ b/game/src/main/java/org/dragonskulle/game/map/MapEffects.java
@@ -141,7 +141,7 @@ public class MapEffects extends Component implements IOnStart, ILateFrameUpdate 
         if (selection.mClear) {
             Reference<HighlightControls> controls = tile.getHighlightControls();
 
-            if (controls.isValid()) {
+            if (Reference.isValid(controls)) {
                 controls.get().setHighlight(0, 0, 0, 0);
             }
             return;
@@ -150,7 +150,7 @@ public class MapEffects extends Component implements IOnStart, ILateFrameUpdate 
 
         Reference<HighlightControls> controls = tile.getHighlightControls();
 
-        if (controls.isValid()) {
+        if (Reference.isValid(controls)) {
             controls.get().setHighlight(selection.mOverlay);
         }
 

--- a/game/src/main/java/org/dragonskulle/game/player/HumanPlayer.java
+++ b/game/src/main/java/org/dragonskulle/game/player/HumanPlayer.java
@@ -161,7 +161,7 @@ public class HumanPlayer extends Component implements IFrameUpdate, IFixedUpdate
                                 .orElse(null);
         }
 
-        if (mPlayer == null || !mPlayer.isValid()) return;
+        if (!Reference.isValid(mPlayer)) return;
 
         if (!mMovedCameraToCapital) {
             TargetMovement targetRig = Scene.getActiveScene().getSingleton(TargetMovement.class);
@@ -181,14 +181,14 @@ public class HumanPlayer extends Component implements IFrameUpdate, IFixedUpdate
             return;
         }
         // Update token
-        if (mPlayer.isValid()) {
+        if (Reference.isValid(mPlayer)) {
             updateVisibleTokens();
         }
     }
 
     private void updateVisibleTokens() {
         mLocalTokens = mPlayer.get().getTokens().get();
-        if (mTokenCounter != null && mTokenCounter.isValid()) {
+        if (Reference.isValid(mTokenCounter)) {
             mTokenCounter.get().setLabelReference(mLocalTokens);
         } else {
             mTokenCounter = getGameObject().getComponent(UITokenCounter.class);
@@ -199,7 +199,7 @@ public class HumanPlayer extends Component implements IFrameUpdate, IFixedUpdate
     public void frameUpdate(float deltaTime) {
         // Choose which screen to show
 
-        if (mMenuDrawer != null && mMenuDrawer.isValid()) {
+        if (Reference.isValid(mMenuDrawer)) {
             mMenuDrawer.get().setMenu(mScreenOn);
         }
 
@@ -297,7 +297,7 @@ public class HumanPlayer extends Component implements IFrameUpdate, IFixedUpdate
         MapEffects effects = mMapEffects.get();
         if (!mPlayer.get().hasLost()) {
 
-            if (mFogOfWar != null && mFogOfWar.isValid()) {
+            if (Reference.isValid(mFogOfWar)) {
                 mFogOfWar.get().setActivePlayer(mPlayer);
             }
 
@@ -309,20 +309,20 @@ public class HumanPlayer extends Component implements IFrameUpdate, IFixedUpdate
                     effects.setHighlightOverlay(null);
                     break;
                 case BUILDING_SELECTED_SCREEN:
-                    if (mMenuDrawer.isValid()) {
-                        if (attack_button != null) {
+                    if (Reference.isValid(mMenuDrawer)) {
+                        if (Reference.isValid(attack_button)) {
                             attack_button.get().setEnabled(true);
                             attack_button.get().getComponent(UIButton.class).get().enable();
                         }
-                        if (sell_button != null && sell_button.isValid()) {
+                        if (Reference.isValid(sell_button)) {
                             sell_button.get().setEnabled(true);
                             sell_button.get().getComponent(UIButton.class).get().enable();
                         }
-                        if (place_button != null && place_button.isValid()) {
+                        if (Reference.isValid(place_button)) {
                             place_button.get().setEnabled(false);
                             place_button.get().getComponent(UIButton.class).get().disable();
                         }
-                        if (upgrade_button != null && upgrade_button.isValid()) {
+                        if (Reference.isValid(upgrade_button)) {
                             upgrade_button.get().setEnabled(true);
                             upgrade_button.get().getComponent(UIButton.class).get().enable();
                         }
@@ -332,20 +332,20 @@ public class HumanPlayer extends Component implements IFrameUpdate, IFixedUpdate
                             (fx) -> highlightSelectedTile(fx, StandardHighlightType.VALID));
                     break;
                 case TILE_SCREEN:
-                    if (mMenuDrawer.isValid()) {
-                        if (attack_button != null && attack_button.isValid()) {
+                    if (Reference.isValid(mMenuDrawer)) {
+                        if (Reference.isValid(attack_button)) {
                             attack_button.get().setEnabled(false);
                             attack_button.get().getComponent(UIButton.class).get().disable();
                         }
-                        if (sell_button != null && sell_button.isValid()) {
+                        if (Reference.isValid(sell_button)) {
                             sell_button.get().setEnabled(false);
                             sell_button.get().getComponent(UIButton.class).get().disable();
                         }
-                        if (place_button != null && place_button.isValid()) {
+                        if (Reference.isValid(place_button)) {
                             place_button.get().setEnabled(true);
                             place_button.get().getComponent(UIButton.class).get().enable();
                         }
-                        if (upgrade_button != null && upgrade_button.isValid()) {
+                        if (Reference.isValid(upgrade_button)) {
                             upgrade_button.get().setEnabled(false);
                             upgrade_button.get().getComponent(UIButton.class).get().disable();
                         }
@@ -355,20 +355,20 @@ public class HumanPlayer extends Component implements IFrameUpdate, IFixedUpdate
                             (fx) -> highlightSelectedTile(fx, StandardHighlightType.PLAIN));
                     break;
                 case ATTACK_SCREEN:
-                    if (mMenuDrawer.isValid()) {
-                        if (attack_button != null && attack_button.isValid()) {
+                    if (Reference.isValid(mMenuDrawer)) {
+                        if (Reference.isValid(attack_button)) {
                             attack_button.get().setEnabled(true);
                             attack_button.get().getComponent(UIButton.class).get().enable();
                         }
-                        if (sell_button != null && sell_button.isValid()) {
+                        if (Reference.isValid(sell_button)) {
                             sell_button.get().setEnabled(false);
                             sell_button.get().getComponent(UIButton.class).get().disable();
                         }
-                        if (place_button != null && place_button.isValid()) {
+                        if (Reference.isValid(place_button)) {
                             place_button.get().setEnabled(false);
                             place_button.get().getComponent(UIButton.class).get().disable();
                         }
-                        if (upgrade_button != null && upgrade_button.isValid()) {
+                        if (Reference.isValid(upgrade_button)) {
                             upgrade_button.get().setEnabled(false);
                             upgrade_button.get().getComponent(UIButton.class).get().disable();
                         }
@@ -420,7 +420,7 @@ public class HumanPlayer extends Component implements IFrameUpdate, IFixedUpdate
      * @return true if the player owns the buildingSelectedView, false if not
      */
     private boolean hasPlayerGotBuilding(Reference<Building> buildingToCheck) {
-        if (buildingToCheck == null || !buildingToCheck.isValid()) return false;
+        if (!Reference.isValid(buildingToCheck)) return false;
 
         return mPlayer.get().getOwnedBuilding(buildingToCheck.get().getTile()) != null;
     }

--- a/game/src/main/java/org/dragonskulle/game/player/Player.java
+++ b/game/src/main/java/org/dragonskulle/game/player/Player.java
@@ -312,7 +312,7 @@ public class Player extends NetworkableComponent implements IOnStart, IFixedUpda
         Reference<NetworkObject> networkObject =
                 getNetworkManager().getServerManager().spawnNetworkObject(playerId, template);
 
-        if (networkObject == null || networkObject.isValid() == false) {
+        if (!Reference.isValid(networkObject)) {
             log.warning("Unable to create building: Could not create a Network Object.");
             return null;
         }
@@ -323,7 +323,7 @@ public class Player extends NetworkableComponent implements IOnStart, IFixedUpda
         transform.setHeight(tile.getHeight());
         Reference<Building> building = gameObject.getComponent(Building.class);
 
-        if (building == null || building.isValid() == false) {
+        if (!Reference.isValid(building)) {
             log.warning("Unable to create building: Reference to Building component is invalid.");
             return null;
         }
@@ -447,7 +447,7 @@ public class Player extends NetworkableComponent implements IOnStart, IFixedUpda
         if (map == null) return false;
 
         mMap = map.getReference(HexagonMap.class);
-        if (mMap == null || mMap.isValid() == false) return false;
+        if (!Reference.isValid(mMap)) return false;
         return true;
     }
 
@@ -898,7 +898,7 @@ public class Player extends NetworkableComponent implements IOnStart, IFixedUpda
     public Building getCapital() {
         if (!mOwnsCapital.get()) return null;
 
-        if (mCapital != null && mCapital.isValid()) {
+        if (Reference.isValid(mCapital)) {
             return mCapital.get();
         }
 

--- a/game/src/main/java/org/dragonskulle/game/player/UILinkedScrollBar.java
+++ b/game/src/main/java/org/dragonskulle/game/player/UILinkedScrollBar.java
@@ -25,7 +25,7 @@ public class UILinkedScrollBar extends Component implements IFrameUpdate, IOnSta
      */
     @Override
     public void frameUpdate(float deltaTime) {
-        if (sliderReference.isValid()) {
+        if (Reference.isValid(sliderReference)) {
             ((UIVerticalSlider) sliderReference.get())
                     .setValue(
                             (float)
@@ -57,7 +57,7 @@ public class UILinkedScrollBar extends Component implements IFrameUpdate, IOnSta
         UIVerticalSlider newSlider =
                 new UIVerticalSlider(
                         (uiSlider, val) -> {
-                            if (scrollRef != null && scrollRef.isValid()) {
+                            if (Reference.isValid(scrollRef)) {
                                 scrollRef
                                         .get()
                                         .setTargetLerpTime(

--- a/game/src/main/java/org/dragonskulle/game/player/UIMenuLeftDrawer.java
+++ b/game/src/main/java/org/dragonskulle/game/player/UIMenuLeftDrawer.java
@@ -122,7 +122,7 @@ public class UIMenuLeftDrawer extends Component implements IFrameUpdate, IOnStar
                 (handle, __) -> {
                     // -- Need way to show different buildingSelectedView
                     Reference<Building> buildingChosen = mGetBuildingChosen.get();
-                    if (buildingChosen != null && buildingChosen.isValid()) {
+                    if (Reference.isValid(buildingChosen)) {
 
                         // TODO Change tiles which can be attacked
                         mSetHexChosen.set(null);
@@ -157,7 +157,7 @@ public class UIMenuLeftDrawer extends Component implements IFrameUpdate, IOnStar
                     if (mGetHexChosen.get() != null) {
                         log.info("Running place button lambda");
                         Reference<Player> player = mGetPlayer.get();
-                        if (player != null && player.isValid()) {
+                        if (Reference.isValid(player)) {
                             player.get()
                                     .getClientBuildRequest()
                                     .invoke(new BuildData(mGetHexChosen.get()));
@@ -186,9 +186,9 @@ public class UIMenuLeftDrawer extends Component implements IFrameUpdate, IOnStar
                     StatType statType = StatType.ATTACK;
 
                     Reference<Player> player = mGetPlayer.get();
-                    if (player != null && player.isValid()) {
+                    if (Reference.isValid(player)) {
                         Reference<Building> buildingChosen = mGetBuildingChosen.get();
-                        if (buildingChosen != null && buildingChosen.isValid()) {
+                        if (Reference.isValid(buildingChosen)) {
                             player.get()
                                     .getClientStatRequest()
                                     .invoke(
@@ -214,9 +214,9 @@ public class UIMenuLeftDrawer extends Component implements IFrameUpdate, IOnStar
                     // sell buildingSelectedView
 
                     Reference<Player> player = mGetPlayer.get();
-                    if (player != null && player.isValid()) {
+                    if (Reference.isValid(player)) {
                         Reference<Building> buildingChosen = mGetBuildingChosen.get();
-                        if (buildingChosen != null && buildingChosen.isValid()) {
+                        if (Reference.isValid(buildingChosen)) {
                             player.get()
                                     .getClientSellRequest()
                                     .invoke(new SellData(buildingChosen.get())); // Send Data
@@ -294,24 +294,24 @@ public class UIMenuLeftDrawer extends Component implements IFrameUpdate, IOnStar
         switch (mScreenOn) {
             case BUILDING_SELECTED_SCREEN:
                 button = mButtonReferences.get("place_button");
-                if (button != null && button.isValid()) {}
+                if (Reference.isValid(button)) {}
 
                 break;
             case TILE_SCREEN:
                 button = mButtonReferences.get("sell_button");
-                if (button != null && button.isValid()) {
+                if (Reference.isValid(button)) {
                     // should disable button
                 }
                 break;
             case ATTACK_SCREEN:
                 button = mButtonReferences.get("attack_button");
-                if (button != null && button.isValid()) {
+                if (Reference.isValid(button)) {
                     // should disable button
                 }
                 break;
             case STAT_SCREEN:
                 button = mButtonReferences.get("upgrade_button");
-                if (button != null && button.isValid()) {
+                if (Reference.isValid(button)) {
                     // should disable button
                 }
                 break;

--- a/game/src/main/java/org/dragonskulle/game/player/UITokenCounter.java
+++ b/game/src/main/java/org/dragonskulle/game/player/UITokenCounter.java
@@ -18,9 +18,9 @@ import org.joml.Vector3f;
 public class UITokenCounter extends Component implements IOnStart {
     public void setLabelReference(int newTokens) {
         Reference<UIButton> buttonRef = getGameObject().getComponent(UIButton.class);
-        if (buttonRef != null && buttonRef.isValid()) {
+        if (Reference.isValid(buttonRef)) {
             Reference<UIText> txt = buttonRef.get().getLabelText();
-            if (txt != null && txt.isValid()) {
+            if (Reference.isValid(txt)) {
                 txt.get().setText("Tokens: " + newTokens);
             }
         }

--- a/game/src/main/java/org/dragonskulle/game/player/ai/ProbabilisticAiPlayer.java
+++ b/game/src/main/java/org/dragonskulle/game/player/ai/ProbabilisticAiPlayer.java
@@ -143,7 +143,7 @@ public class ProbabilisticAiPlayer extends AiPlayer {
 
         int buildingIndex = mRandom.nextInt(getPlayer().getNumberOfOwnedBuildings());
         Reference<Building> buildingReference = getPlayer().getOwnedBuildings().get(buildingIndex);
-        if (buildingReference == null || buildingReference.isValid() == false) {
+        if (!Reference.isValid(buildingReference)) {
             log.info("AI: could not get building to upgrade.");
             return false;
         }
@@ -222,7 +222,7 @@ public class ProbabilisticAiPlayer extends AiPlayer {
             int buildingIndex = mRandom.nextInt(getPlayer().getNumberOfOwnedBuildings());
             Reference<Building> buildingReference =
                     getPlayer().getOwnedBuildings().get(buildingIndex);
-            if (buildingReference == null || buildingReference.isValid() == false) {
+            if (!Reference.isValid(buildingReference)) {
                 log.info("AI: could not get building to sell.");
                 return false;
             }


### PR DESCRIPTION
We use this `mVar != null && mVar.isValid()` pattern quite a lot, and I believe it's both very verbose and error prone. After discussing with @MadMin3r I've decided to move `mVar != null` check into the `Reference::isValid` method.

This required it to be changed into static, so all the `mVar != null && mVar.isValid()` lines become `Reference.isValid(mVar)`

`Reference.isInvalid()` was also added for use in streams and such, but I don't feel like it should be used often (only used in streams), since `!Reference.isInvalid()` would be one of the most confusing expressions.