### PR TITLE
Improve highlight effect

### DIFF
--- a/game/src/main/java/org/dragonskulle/game/map/MapEffects.java
+++ b/game/src/main/java/org/dragonskulle/game/map/MapEffects.java
@@ -13,7 +13,6 @@ import org.dragonskulle.core.Reference;
 import org.dragonskulle.core.Scene;
 import org.dragonskulle.game.materials.HighlightControls;
 import org.dragonskulle.game.player.Player;
-import org.dragonskulle.renderer.SampledTexture;
 import org.dragonskulle.renderer.materials.*;
 import org.joml.Vector4f;
 
@@ -114,12 +113,8 @@ public class MapEffects extends Component implements IOnStart, ILateFrameUpdate 
 
     @Getter @Setter private Reference<Player> mActivePlayer;
 
-    public static IRefCountedMaterial highlightMaterialFromColour(float r, float g, float b) {
-        return new UnlitMaterial(new SampledTexture("white.bmp"), new Vector4f(r, g, b, 0.5f));
-    }
-
     public static HighlightSelection highlightSelectionFromColour(float r, float g, float b) {
-        return HighlightSelection.with(new Vector4f(r, g, b, 0.8f));
+        return HighlightSelection.with(new Vector4f(r, g, b, 0.2f));
     }
 
     /**

--- a/game/src/main/java/org/dragonskulle/game/materials/PBRHighlightMaterial.java
+++ b/game/src/main/java/org/dragonskulle/game/materials/PBRHighlightMaterial.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.dragonskulle.renderer.AttributeDescription;
 import org.dragonskulle.renderer.SampledTexture;
@@ -38,15 +39,25 @@ public class PBRHighlightMaterial extends PBRMaterial {
                     "highlight_pbr",
                     new ArrayList<>(),
                     new ArrayList<>(),
-                    OVERLAY_COL_OFFSET + 4 * 4,
+                    OVERLAY_ALPHAMUL_OFFSET + 4 * 4,
                     new AttributeDescription(
-                            1, 0, VK_FORMAT_R32G32B32A32_SFLOAT, OVERLAY_COL_OFFSET));
+                            1, 0, VK_FORMAT_R32G32B32A32_SFLOAT, OVERLAY_COL_OFFSET),
+                    new AttributeDescription(1, 1, VK_FORMAT_R32_SFLOAT, OVERLAY_MINDIST_OFFSET),
+                    new AttributeDescription(1, 2, VK_FORMAT_R32_SFLOAT, OVERLAY_DISTPOW_OFFSET),
+                    new AttributeDescription(1, 3, VK_FORMAT_R32_SFLOAT, OVERLAY_ALPHAMUL_OFFSET));
         }
     }
 
     private static final int OVERLAY_COL_OFFSET = 0;
+    private static final int OVERLAY_MINDIST_OFFSET = OVERLAY_COL_OFFSET + 4 * 4;
+    private static final int OVERLAY_DISTPOW_OFFSET = OVERLAY_MINDIST_OFFSET + 4;
+    private static final int OVERLAY_ALPHAMUL_OFFSET = OVERLAY_DISTPOW_OFFSET + 4;
 
     @Getter private Vector4f mOverlayColour = new Vector4f(0f);
+
+    @Getter @Setter private float mMinDist = 0.5f;
+    @Getter @Setter private float mDistPow = 5f;
+    @Getter @Setter private float mAlphaMul = 4f;
 
     @Override
     protected int hashShaderSet() {
@@ -109,7 +120,10 @@ public class PBRHighlightMaterial extends PBRMaterial {
             int offset, ByteBuffer buffer, Matrix4fc matrix, List<Light> lights) {
         offset = super.writeVertexInstanceData(offset, buffer, matrix, lights);
         mOverlayColour.get(offset + OVERLAY_COL_OFFSET, buffer);
-        return offset + 4 * 4;
+        buffer.putFloat(offset + OVERLAY_MINDIST_OFFSET, mMinDist);
+        buffer.putFloat(offset + OVERLAY_DISTPOW_OFFSET, mDistPow);
+        buffer.putFloat(offset + OVERLAY_ALPHAMUL_OFFSET, mAlphaMul);
+        return offset + OVERLAY_ALPHAMUL_OFFSET + 4;
     }
 
     public ShaderSet getShaderSet() {

--- a/game/src/main/resources/shaders/highlight_pbr.frag
+++ b/game/src/main/resources/shaders/highlight_pbr.frag
@@ -4,11 +4,19 @@
 #include "pbr_frag_base.glsl"
 
 layout(location = LAST_IN_LOCATION + 1) in vec4 inOverlay;
+layout(location = LAST_IN_LOCATION + 2) in float inMinDist;
+layout(location = LAST_IN_LOCATION + 3) in float inDistPow;
+layout(location = LAST_IN_LOCATION + 4) in float inAlphaMul;
 
 void main() {
 	vec4 color = pbr_base();
 
-	color.rgb = mix(color.rgb, inOverlay.rgb, inOverlay.a);
+	float dist = length(fragUV - vec2(0.5));
+	float lerp = min(dist / inMinDist, 1.0);
+	float add = pow(lerp, inDistPow);
+	vec4 col = inOverlay + ((vec4(inOverlay.rgb, 1.0) * vec4(vec3(fragColor.a), min(1.0, inOverlay.a * inAlphaMul)) * add));
+
+	color.rgb = mix(color.rgb, inOverlay.rgb, col.a);
 
 	// Tonemap
 	// TODO: Do this in post-processing effect

--- a/game/src/main/resources/shaders/highlight_pbr.vert
+++ b/game/src/main/resources/shaders/highlight_pbr.vert
@@ -4,9 +4,19 @@
 #include "pbr_vert_base.glsl"
 
 layout(location = LAST_IN_LOCATION + 1) in vec4 inOverlay;
+layout(location = LAST_IN_LOCATION + 2) in float inMinDist;
+layout(location = LAST_IN_LOCATION + 3) in float inDistPow;
+layout(location = LAST_IN_LOCATION + 4) in float inAlphaMul;
+
 layout(location = LAST_OUT_LOCATION + 1) out vec4 outOverlay;
+layout(location = LAST_OUT_LOCATION + 2) out float outMinDist;
+layout(location = LAST_OUT_LOCATION + 3) out float outDistPow;
+layout(location = LAST_OUT_LOCATION + 4) out float outAlphaMul;
 
 void main() {
 	pbr_base();
 	outOverlay = inOverlay;
+	outMinDist = inMinDist;
+	outDistPow = inDistPow;
+	outAlphaMul = inAlphaMul;
 }


### PR DESCRIPTION
Another one of my procrastonaty change - improved highlighting.

Essentially, I was told that it's rather confusing to see which tile means what, and stuff like water can easily be confused with enemy territory. So, I brought back similar style of highlighting to what we had at the start. Now, hex edges get some more intense highlighting, making it much easier to distinguish whether it is just a highlight or the colour a tile has regularly:

![Screenshot from 2021-04-13 00-02-29](https://user-images.githubusercontent.com/22240533/114473579-6f7d4580-9bec-11eb-85c6-aba8bce7916a.png)

![Screenshot from 2021-04-13 00-02-19](https://user-images.githubusercontent.com/22240533/114473547-5d030c00-9bec-11eb-8a4a-5006888478c7.png)

![Screenshot from 2021-04-13 00-02-51](https://user-images.githubusercontent.com/22240533/114473525-51174a00-9bec-11eb-8250-bce977b4436a.png)

![Screenshot from 2021-04-13 00-02-39](https://user-images.githubusercontent.com/22240533/114473602-7a37da80-9bec-11eb-9f43-d1a57f43fffc.png)
