### PR TITLE
Move AudioManager update to after every fixedUpdate

### DIFF
--- a/engine/src/main/java/org/dragonskulle/core/Engine.java
+++ b/engine/src/main/java/org/dragonskulle/core/Engine.java
@@ -260,6 +260,7 @@ public class Engine {
                     cumulativeDeltaTime -= UPDATE_TIME;
 
                     fixedUpdate();
+                    AudioManager.getInstance().update();
                 } while (cumulativeTime > UPDATE_TIME);
             }
 
@@ -270,8 +271,6 @@ public class Engine {
 
                 // Call LateFrameUpdate on the presentation scene
                 lateFrameUpdate((float) deltaTime);
-
-                AudioManager.getInstance().update();
 
                 renderFrame();
                 Scene.setActiveScene(null);


### PR DESCRIPTION
AudioListener lagged behind camera position causing sound to come from different directions depending on movement. Did not sound nice.

Signed-off-by: Harry Stoltz <hbstoltz7@gmail.com>