### PR TITLE
Implement frustum culling

### DIFF
--- a/engine/src/main/java/org/dragonskulle/ui/UIRenderable.java
+++ b/engine/src/main/java/org/dragonskulle/ui/UIRenderable.java
@@ -13,6 +13,7 @@ import org.dragonskulle.renderer.SampledTexture;
 import org.dragonskulle.renderer.Texture;
 import org.dragonskulle.renderer.components.Light;
 import org.dragonskulle.renderer.components.Renderable;
+import org.joml.FrustumIntersection;
 import org.joml.Matrix4f;
 import org.joml.Vector2fc;
 import org.joml.Vector3f;
@@ -121,6 +122,11 @@ public class UIRenderable extends Renderable implements IOnAwake {
     @Override
     public float getDepth(Vector3fc camPosition, Vector3f tmpVec) {
         return (float) -getGameObject().getDepth() + mDepthShift;
+    }
+
+    @Override
+    public boolean frustumCull(FrustumIntersection intersection) {
+        return true;
     }
 
     public boolean cursorOver() {

--- a/engine/src/main/java/org/dragonskulle/ui/UIText.java
+++ b/engine/src/main/java/org/dragonskulle/ui/UIText.java
@@ -20,6 +20,7 @@ import org.dragonskulle.renderer.Vertex;
 import org.dragonskulle.renderer.components.Light;
 import org.dragonskulle.renderer.components.Renderable;
 import org.dragonskulle.utils.MathUtils;
+import org.joml.FrustumIntersection;
 import org.joml.Matrix4fc;
 import org.joml.Vector2f;
 import org.joml.Vector3f;
@@ -339,6 +340,11 @@ public class UIText extends Renderable implements IOnAwake, IFrameUpdate {
     @Override
     public float getDepth(Vector3fc camPosition, Vector3f tmpVec) {
         return (float) -getGameObject().getDepth() + mDepthShift;
+    }
+
+    @Override
+    public boolean frustumCull(FrustumIntersection intersection) {
+        return true;
     }
 
     @Override


### PR DESCRIPTION
Frustum culling is a simple optimisation that skips drawing objects that are off-screen. This branch implements it. Performance should be improved, especially when not looking at the whole map.